### PR TITLE
Fix fees by removing account based fee splitting

### DIFF
--- a/libraries/chain/account_object.cpp
+++ b/libraries/chain/account_object.cpp
@@ -69,8 +69,6 @@ void account_statistics_object::process_fees(const account_object& a, database& 
          assert( network_cut <= core_fee_total );
 
 #ifndef NDEBUG
-         const auto& props = d.get_global_properties();
-
          share_type reserveed = cut_fee(network_cut, props.parameters.reserve_percent_of_fee);
          share_type accumulated = network_cut - reserveed;
          assert( accumulated + reserveed == network_cut );

--- a/libraries/chain/account_object.cpp
+++ b/libraries/chain/account_object.cpp
@@ -63,7 +63,9 @@ void account_statistics_object::process_fees(const account_object& a, database& 
                acc.referrer = acc.lifetime_referrer;
             });
 
-         share_type network_cut = cut_fee(core_fee_total, account.network_fee_percentage);
+         const auto& props = d.get_global_properties();
+
+         share_type network_cut = cut_fee(core_fee_total, props.parameters.network_percent_of_fee);
          assert( network_cut <= core_fee_total );
 
 #ifndef NDEBUG
@@ -73,11 +75,14 @@ void account_statistics_object::process_fees(const account_object& a, database& 
          share_type accumulated = network_cut - reserveed;
          assert( accumulated + reserveed == network_cut );
 #endif
-         share_type lifetime_cut = cut_fee(core_fee_total, account.lifetime_referrer_fee_percentage);
-         share_type marketing_partner_cut = cut_fee(core_fee_total, account.marketing_partner_fee_percentage);
-         share_type charity_cut = cut_fee(core_fee_total, account.charity_fee_percentage);
-         share_type referral = core_fee_total - network_cut - lifetime_cut - marketing_partner_cut - charity_cut;
+         share_type lifetime_cut = cut_fee(core_fee_total, props.parameters.lifetime_referrer_percent_of_fee);
+         share_type marketing_partner_cut = cut_fee(core_fee_total, GRAPHENE_DEFAULT_MARKETING_PARTNER_PERCENT_OF_FEE);
+         share_type charity_cut = cut_fee(core_fee_total, GRAPHENE_DEFAULT_CHARITY_PERCENT_OF_FEE);
 
+         assert( core_fee_total - network_cut - lifetime_cut - marketing_partner_cut - charity_cut >= 0 );
+
+         share_type referral = core_fee_total - network_cut - lifetime_cut - marketing_partner_cut - charity_cut;
+         
          d.modify( d.get_core_dynamic_data(), [network_cut, marketing_partner_cut, charity_cut](asset_dynamic_data_object& addo) {
             addo.accumulated_fees += network_cut;
             addo.accumulated_fees_for_marketing_partner += marketing_partner_cut;

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -547,7 +547,6 @@ void database::init_genesis(const genesis_state_type& genesis_state)
    }
 
    const auto& idx = get_index_type<asset_index>().indices().get<by_symbol>();
-   auto it = idx.begin();
 
    // Save tallied supplies
    for( const auto& item : total_supplies )

--- a/libraries/chain/include/graphene/chain/config.hpp
+++ b/libraries/chain/include/graphene/chain/config.hpp
@@ -98,7 +98,7 @@
 // ********** Fee split settings
 // The below settings define how the overall chain fees get split
 #define GRAPHENE_DEFAULT_NETWORK_PERCENT_OF_FEE               (10*GRAPHENE_1_PERCENT)
-#define GRAPHENE_DEFAULT_LIFETIME_REFERRER_PERCENT_OF_FEE     (30*GRAPHENE_1_PERCENT)
+#define GRAPHENE_DEFAULT_LIFETIME_REFERRER_PERCENT_OF_FEE     (10*GRAPHENE_1_PERCENT)
 #define GRAPHENE_DEFAULT_BURN_PERCENT_OF_FEE                  (20*GRAPHENE_1_PERCENT)
 
 // These two are not initially votable by the committee


### PR DESCRIPTION
This forces the fee splitting to pull from chain parameters rather than each account object. This renders the following account object percentage params unused:

network, lifetime referrer, marketing partner, and charity fee