### PR TITLE
Changed BitShares to TUSC

### DIFF
--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
          exit_promise->set_value(signal);
       }, SIGTERM);
 
-      ilog("Started BitShares node on a chain with ${h} blocks.", ("h", node->chain_database()->head_block_num()));
+      ilog("Started TUSC node on a chain with ${h} blocks.", ("h", node->chain_database()->head_block_num()));
       ilog("Chain ID is ${id}", ("id", node->chain_database()->get_chain_id()) );
 
       int signal = exit_promise->wait();


### PR DESCRIPTION
It was showing "Started BitShares node on a chain with 0 blocks." It is changed to "Started TUSC node on a chain with 0 blocks."